### PR TITLE
make params optional in DataTableProviderProps interface

### DIFF
--- a/src/components/core/data-table/provider.tsx
+++ b/src/components/core/data-table/provider.tsx
@@ -5,7 +5,7 @@ import { DataTableContext } from './context';
 
 export interface DataTableProviderProps extends PropsWithChildren {
   context: string;
-  params: ParamsType;
+  params?: ParamsType;
 }
 
 export function DataTableProvider({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The data table component now supports optional configuration inputs, allowing greater flexibility when setting up and using the feature without requiring extra parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->